### PR TITLE
dynamically importing express to prevent module not found

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
-const express = require('express');
-const server = express();
-
 const runServer = (bot, port = 3000) => {
+	const express = require('express');
+	const server = express();
+
 	server.use(express.json());
 
 	server.post('/', (req, res) => {


### PR DESCRIPTION
Added lazy loading for express using `require` function in order to prevent `module not found` error in cases of:
1. Not using `express`.
2. In case using `Telenode` only for sending messages without any handlers.