### PR TITLE
Improve long polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ If you prefer to use long polling method over creating a server with webhook you
 <br>
 The method accepts `pollingDelay` - a number that represents milliseconds (must be at least 50ms).
 <br>
+By default the long polling mechanism will ignore all previous updates (`cleanPreviousUpdates` by default is `true`). You can toggle off `cleanPreviousUpdates` if you want to by setting it as `false` when you call `startLongPolling`.
+<br>
+You also can stop the long polling while it's running by setting `bot.useLongPolling` to `false`.
+<br>
 You can view an example of long polling usage [here](https://github.com/NivEz/telenode/tree/main/examples/long-polling.js).
 
 Note that long polling is usually not recommended and webhook is preferred for most use cases.

--- a/examples/long-polling.js
+++ b/examples/long-polling.js
@@ -27,3 +27,8 @@ const inlineKeyboard = [
 		},
 	],
 ];
+
+// After 30 seconds the long polling will stop
+setTimeout(() => {
+	bot.useLongPolling = false;
+}, 30000);

--- a/src/bot.js
+++ b/src/bot.js
@@ -13,17 +13,23 @@ class Telenode {
 		this.buttonHandlers = {};
 		this.#baseUrl = 'https://api.telegram.org/bot' + apiToken;
 		this.#secretToken = secretToken;
+		this.useLongPolling = false;
 	}
 
 	createServer({ port, unauthorizedCallback } = {}) {
 		this.unauthorizedHandler = unauthorizedCallback;
+		if (this.useLongPolling) {
+			throw Error('Cannot start server while long polling is active');
+		}
 		runServer(this, port);
 	}
 
-	startLongPolling({ pollingDelay } = {}) {
+	startLongPolling({ pollingDelay, cleanPreviousUpdates } = {}) {
+		this.useLongPolling = true;
 		longPoll({
 			bot: this,
 			pollingDelay,
+			cleanPreviousUpdates,
 			url: this.#baseUrl,
 		});
 	}


### PR DESCRIPTION
Imrpoved long polling by:
1. Added `cleanPreviousUpdates` that enables to clean all previous updates before the polling itself.
2. Added the option to stop the bot from polling while it's running.