### PR TITLE
fixed husky installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
 		"": {
 			"name": "telenode-js",
 			"version": "1.4.0",
-			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.6.5"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"publish:dry": "npm publish --dry-run",
 		"set-webhook": "node ./scripts/setWebhook.js",
 		"delete-webhook": "node ./scripts/deleteWebhook.js",
-		"postinstall": "husky install",
+		"prepare": "node -e \"!process.env.GITHUB_ACTIONS && process.exit(1)\" || husky install",
 		"format": "npx prettier . --write"
 	},
 	"bin": {


### PR DESCRIPTION
* Changed back husky installation part from `postinstall` to `prepare`.
* Added condition that the `husky install` command will run only locally (not in CI) since `husky install` doesn't work with `JS-DevTools/npm-publish@v1`.
